### PR TITLE
Correctly filter NoOp from v1 version.

### DIFF
--- a/atoti-query-analyser/src/helpers/v1tov2.js
+++ b/atoti-query-analyser/src/helpers/v1tov2.js
@@ -257,7 +257,11 @@ const parseMeasures = measures => {
     ? []
     : measures.substring(1, measures.length - 1).split(/\s*,\s*/);
 };
-const parseTimings = props => {
+const parseTimings = (type, props) => {
+  if (type.includes("NoOp")) {
+    return {};
+  }
+  
   const starts = props["Start time   (in ms)"];
   const elapsed = props["Elapsed time (in ms)"];
   if (starts && elapsed) {
@@ -311,7 +315,7 @@ const createRetrievalMap = (v1Structure, filters) => {
       type: retrieval.type,
       location: parseLocation(retrieval.properties.Location),
       measures: parseMeasures(retrieval.properties.Measures),
-      timingInfo: parseTimings(retrieval.properties),
+      timingInfo: parseTimings(retrieval.type, retrieval.properties),
       partitioning: retrieval.properties.Partitioning,
       filterId: findFilter(filters, retrieval.properties.Filter),
       measureProvider: retrieval.properties["Measures provider"],


### PR DESCRIPTION
When timing was enabled, v1 query plans export start and elapsed times for NoOp retrievals. This resulted in NoOps being displayed into the Graph.