### PR TITLE
PIVOT-6910 Cannot inspect query plan generated by 6.0.3

### DIFF
--- a/atoti-query-analyser/src/components/Details/Details.tsx
+++ b/atoti-query-analyser/src/components/Details/Details.tsx
@@ -46,6 +46,18 @@ Values.defaultProps = {
 };
 
 /**
+ * Renders a part of a location path
+ * @param pathPart - part of the path to be displayed
+ */
+function renderPathPart(pathPart: string | string[]): string {
+  if (Array.isArray(pathPart)) {
+    return "[" + pathPart.join(", ") + "]";
+  } else {
+    return pathPart;
+  }
+}
+
+/**
  * React component that renders a list of {@link "library/dataStructures/json/cubeLocation"!CubeLocation}.
  * @param attributes - React JSX attributes
  * @param attributes.location - list of locations to be displayed.
@@ -62,7 +74,7 @@ function LocationView({ location }: { location: CubeLocation[] }) {
               {l.level.map((lev, i) => (
                 <li key={lev}>
                   <b>{lev + ": "}</b>
-                  {l.path[i]}
+                  {renderPathPart(l.path[i])}
                 </li>
               ))}
             </ul>

--- a/atoti-query-analyser/src/library/dataStructures/json/cubeLocation.ts
+++ b/atoti-query-analyser/src/library/dataStructures/json/cubeLocation.ts
@@ -1,6 +1,7 @@
 import {
   validateList,
   validateObject,
+  validatePath,
   validateString,
 } from "./validatingUtils";
 
@@ -8,7 +9,7 @@ export interface CubeLocation {
   dimension: string;
   hierarchy: string;
   level: string[];
-  path: string[];
+  path: (string | string[])[];
 }
 
 // Reason: `validate...()` function
@@ -24,6 +25,6 @@ export function validateLocation(rawLocation: any): CubeLocation {
     dimension: validateString(rawLocation.dimension),
     hierarchy: validateString(rawLocation.hierarchy),
     level: validateList(rawLocation.level, validateString),
-    path: validateList(rawLocation.path, validateString),
+    path: validateList(rawLocation.path, validatePath),
   };
 }

--- a/atoti-query-analyser/src/library/dataStructures/json/validatingUtils.ts
+++ b/atoti-query-analyser/src/library/dataStructures/json/validatingUtils.ts
@@ -38,7 +38,17 @@ export function validateBoolean(rawBoolean: any): boolean {
  */
 export function validateString(rawString: any): string {
   if (typeof rawString !== "string") {
-    throw new Error(`Expected string, got ${typeof rawString}`);
+    throw new Error(`Expected string or string[], got ${typeof rawString}`);
+  }
+  return rawString;
+}
+
+/**
+ * Check if input is a string or a list of strings.
+ */
+export function validatePath(rawString: any): string | string[] {
+  if (!Array.isArray(rawString) && typeof rawString !== "string") {
+    throw new Error(`Expected string or string[], got ${typeof rawString}`);
   }
   return rawString;
 }


### PR DESCRIPTION
The path of a cube location was assumed to be an array containing strings only. But a path may contain also a list of strings  when a location points to a list of members (ex : [EUR, USD, GBP]). The query plan validator throws an exception since expected and actual types are different.