### PR TITLE
Improve the timeline view

### DIFF
--- a/atoti-query-analyser/src/components/Timeline/Timeline.css
+++ b/atoti-query-analyser/src/components/Timeline/Timeline.css
@@ -4,6 +4,9 @@
 
 .timeline-rows {
   overflow-x: auto;
+  overflow-y: auto;
+  max-width: 100vw;
+  max-height: 90vh;
 }
 
 .timeline-box {

--- a/atoti-query-analyser/src/components/Timeline/Timeline.css
+++ b/atoti-query-analyser/src/components/Timeline/Timeline.css
@@ -9,6 +9,11 @@
   max-height: 90vh;
 }
 
+.timeline-index {
+  fill: #959595;
+  font-size: 0.8rem;
+}
+
 .timeline-box {
   fill: rgb(0, 146, 204);
   rx: 3px;

--- a/atoti-query-analyser/src/components/Timeline/Timeline.tsx
+++ b/atoti-query-analyser/src/components/Timeline/Timeline.tsx
@@ -223,7 +223,9 @@ function Rows({
   return (
     <div className="timeline-rows">
       <svg width={width} height={height}>
-        {rows.map((row, idx) => Row({ row, idx, graph, selection, onSelect }))}
+        {[...rows]
+          .reverse()
+          .map((row, idx) => Row({ row, idx, graph, selection, onSelect }))}
       </svg>
     </div>
   );

--- a/atoti-query-analyser/src/components/Timeline/Timeline.tsx
+++ b/atoti-query-analyser/src/components/Timeline/Timeline.tsx
@@ -119,12 +119,14 @@ function Box({
   node,
   selection,
   onSelect,
+  textOffset,
 }: {
   rowIdx: number;
   entry: TimeRange;
   node: RetrievalVertex;
   selection: RetrievalCursor[];
   onSelect: (entry: TimeRange) => void;
+  textOffset: number;
 }) {
   if (node === undefined || entry.retrieval.id !== node.getUUID()) {
     throw new Error(
@@ -143,7 +145,7 @@ function Box({
       <rect
         key={key}
         className={`timeline-box ${selected ? "selected" : ""}`}
-        x={MARGIN + x}
+        x={textOffset + MARGIN + x}
         y={MARGIN + rowIdx * (BOX_MARGIN + BOX_HEIGHT)}
         width={w}
         height={BOX_HEIGHT}
@@ -157,7 +159,7 @@ function Box({
     <rect
       key={key}
       className={`timeline-box ${selected ? "selected" : ""}`}
-      x={MARGIN + x}
+      x={textOffset + MARGIN + x}
       y={MARGIN + rowIdx * (BOX_MARGIN + BOX_HEIGHT)}
       width={w}
       height={BOX_HEIGHT}
@@ -175,12 +177,14 @@ function Row({
   graph,
   selection,
   onSelect,
+  textOffset,
 }: {
   row: TimeRange[];
   idx: number;
   graph: RetrievalGraph;
   selection: RetrievalCursor[];
   onSelect: (entry: TimeRange) => void;
+  textOffset: number;
 }) {
   const boxes = row.map((entry) =>
     Box({
@@ -189,14 +193,38 @@ function Row({
       node: graph.getVertexByUUID(entry.retrieval.id),
       selection,
       onSelect,
+      textOffset,
     })
   );
   return (
     <g className="timeline-row" key={idx}>
+      <text
+        className="timeline-index"
+        x={textOffset / 2}
+        y={MARGIN + idx * (BOX_MARGIN + BOX_HEIGHT) + BOX_HEIGHT / 2}
+        width={textOffset}
+        height={BOX_HEIGHT}
+        dominantBaseline={"middle"}
+        textAnchor={"middle"}
+      >
+        {idx + 1}
+      </text>
       {boxes}
     </g>
   );
 }
+
+const computeTextOffset = (rowCount: number) => {
+  if (rowCount < 10) {
+    return 15;
+  } else if (rowCount < 100) {
+    return 20;
+  } else if (rowCount < 1000) {
+    return 25;
+  } else {
+    return 30;
+  }
+};
 
 /**
  * This React component is responsible for rendering timeline.
@@ -220,12 +248,20 @@ function Rows({
       Math.max(
         ...rows.map((row) => row[row.length - 1]).map((entry) => entry.end)
       );
+  const textOffset = computeTextOffset(rows.length);
   return (
     <div className="timeline-rows">
       <svg width={width} height={height}>
-        {[...rows]
-          .reverse()
-          .map((row, idx) => Row({ row, idx, graph, selection, onSelect }))}
+        {[...rows].reverse().map((row, idx) =>
+          Row({
+            row,
+            idx,
+            graph,
+            selection,
+            onSelect,
+            textOffset,
+          })
+        )}
       </svg>
     </div>
   );


### PR DESCRIPTION
This operates several minimal changes over the timeline view.

The top timeline is now the one taking the most time, when previously it was at the bottom and long to find.

The timeline rows will automatically scroll vertically when there are too many rows to fit on the screen.

The timeline rows are now numbered, to quickly see how many operations are running in parallel.

![image](https://github.com/activeviam/activeviam.github.io/assets/1181415/5dd6768a-2ecd-4f05-a12a-0d34712d6d2f)
