### PR TITLE
Add focus and relative operations in the timeline

### DIFF
--- a/atoti-query-analyser/src/components/Details/Details.css
+++ b/atoti-query-analyser/src/components/Details/Details.css
@@ -1,3 +1,9 @@
+.level-depth {
+  font-size: 0.8rem;
+  color: #999999;
+  padding-right: 3px;
+}
+
 .selected-partition {
   color: red;
   font-weight: bold;

--- a/atoti-query-analyser/src/components/Details/Details.tsx
+++ b/atoti-query-analyser/src/components/Details/Details.tsx
@@ -29,7 +29,7 @@ function Values({ values, selected }: { values: number[]; selected?: number }) {
     <>
       [
       {values.map((v, i, vs) => (
-        <span key={v}>
+        <span key={i}>
           <span className={i === selected ? "selected-partition" : ""}>
             {v}
           </span>

--- a/atoti-query-analyser/src/components/Details/Details.tsx
+++ b/atoti-query-analyser/src/components/Details/Details.tsx
@@ -57,6 +57,10 @@ function renderPathPart(pathPart: string | string[]): string {
   }
 }
 
+const isOnlyAllMember = (axisLocation: CubeLocation): boolean => {
+  return axisLocation.path.length === 1 && axisLocation.level[0] === "ALL";
+};
+
 /**
  * React component that renders a list of {@link "library/dataStructures/json/cubeLocation"!CubeLocation}.
  * @param attributes - React JSX attributes
@@ -67,19 +71,24 @@ function LocationView({ location }: { location: CubeLocation[] }) {
     <li>
       Location:
       <ul>
-        {location.map((l) => (
-          <li key={`${l.dimension}@${l.hierarchy}`}>
-            {l.dimension}: {l.hierarchy}
-            <ul>
-              {l.level.map((lev, i) => (
-                <li key={lev}>
-                  <b>{lev + ": "}</b>
-                  {renderPathPart(l.path[i])}
-                </li>
-              ))}
-            </ul>
-          </li>
-        ))}
+        {location.map((l) =>
+          isOnlyAllMember(l) ? null : (
+            <li key={`${l.dimension}@${l.hierarchy}`}>
+              {l.dimension}: {l.hierarchy}
+              <ul>
+                {l.level.map((lev, i) =>
+                  i === 0 && lev === "ALL" ? null : (
+                    <li key={lev}>
+                      <span className="level-depth">[{i}]</span>
+                      <b>{lev + ": "}</b>
+                      {renderPathPart(l.path[i])}
+                    </li>
+                  )
+                )}
+              </ul>
+            </li>
+          )
+        )}
       </ul>
     </li>
   );

--- a/atoti-query-analyser/src/components/ErrorBoundary/ErrorBoundary.tsx
+++ b/atoti-query-analyser/src/components/ErrorBoundary/ErrorBoundary.tsx
@@ -71,7 +71,7 @@ export class ErrorBoundary extends React.Component<
   }
 
   componentDidCatch(error: unknown, errorInfo: React.ErrorInfo) {
-    console.log(error, errorInfo);
+    console.error(error, errorInfo);
   }
 
   render() {

--- a/atoti-query-analyser/src/components/Input/Input.tsx
+++ b/atoti-query-analyser/src/components/Input/Input.tsx
@@ -474,7 +474,6 @@ export function Input({
                 }
                 setInput(result);
                 setProcessing(false);
-                console.log(result.length);
               };
               reader.onerror = (readerEvent) => {
                 showError(

--- a/atoti-query-analyser/src/components/Timeline/Timeline.css
+++ b/atoti-query-analyser/src/components/Timeline/Timeline.css
@@ -28,11 +28,23 @@
 }
 
 .timeline-box.selected {
-  fill: rgb(218, 179, 5);
+  fill: #4ccd9981;
 }
 
 .timeline-box.focused {
-  fill: rgb(255, 223, 43);
+  fill: #4CCD99;
+}
+
+.timeline-box.sibling {
+  fill: #90D26D;
+}
+
+.timeline-box.parent {
+  fill: #2C7865;
+}
+
+.timeline-box.child {
+  fill: #D9EDBF;
 }
 
 .timeline-details {

--- a/atoti-query-analyser/src/components/Timeline/Timeline.css
+++ b/atoti-query-analyser/src/components/Timeline/Timeline.css
@@ -23,28 +23,27 @@
 }
 
 .timeline-box {
-  fill: rgb(0, 146, 204);
-  rx: 3px;
+  fill: #198db4;
 }
 
 .timeline-box.selected {
-  fill: #4ccd9981;
+  fill: #64CCC5;
 }
 
 .timeline-box.focused {
-  fill: #4CCD99;
+  fill: #E9B824;
 }
 
 .timeline-box.sibling {
-  fill: #90D26D;
+  fill: #ffd145;
 }
 
 .timeline-box.parent {
-  fill: #2C7865;
+  fill: #D83F31;
 }
 
 .timeline-box.child {
-  fill: #D9EDBF;
+  fill: #EE9322;
 }
 
 .timeline-details {

--- a/atoti-query-analyser/src/components/Timeline/Timeline.css
+++ b/atoti-query-analyser/src/components/Timeline/Timeline.css
@@ -38,6 +38,7 @@
 .timeline-details .entry {
   display: inline-block !important;
   vertical-align: top;
+  max-width: 500px;
 }
 
 .timeline-details .entry + .entry {
@@ -45,7 +46,7 @@
 }
 
 .timeline-details .body {
-  overflow-x: scroll;
+  overflow-x: auto;
 }
 
 .timeline-details .body ul {

--- a/atoti-query-analyser/src/components/Timeline/Timeline.css
+++ b/atoti-query-analyser/src/components/Timeline/Timeline.css
@@ -9,10 +9,10 @@
 }
 
 .timeline-rows {
-  /* overflow-x: auto; */
+  overflow-x: auto;
   overflow-y: auto;
   max-width: 100vw;
-  max-height: 80vh;
+  max-height: 50vh;
   display: flex;
   flex-direction: row;
 }
@@ -32,6 +32,7 @@
 }
 
 .timeline-details {
+  margin-top: 10px;
   overflow-x: auto;
 }
 
@@ -39,6 +40,18 @@
   display: inline-block !important;
   vertical-align: top;
   max-width: 500px;
+}
+
+.timeline-details .entry .toast-header {
+  align-items: baseline;
+}
+
+.timeline-details .entry .retrieval-id {
+  font-weight: bold;
+}
+
+.timeline-details .entry .retrieval-type {
+  font-size: 0.8rem;
 }
 
 .timeline-details .entry + .entry {

--- a/atoti-query-analyser/src/components/Timeline/Timeline.css
+++ b/atoti-query-analyser/src/components/Timeline/Timeline.css
@@ -28,7 +28,11 @@
 }
 
 .timeline-box.selected {
-  fill: rgb(255, 211, 116);
+  fill: rgb(218, 179, 5);
+}
+
+.timeline-box.focused {
+  fill: rgb(255, 223, 43);
 }
 
 .timeline-details {

--- a/atoti-query-analyser/src/components/Timeline/Timeline.tsx
+++ b/atoti-query-analyser/src/components/Timeline/Timeline.tsx
@@ -536,10 +536,10 @@ export function Timeline({ plan }: { plan: QueryPlan }) {
             const retrievalId = metadata.retrievalId;
             const type = "type" in metadata ? (metadata.type as string) : kind;
             const timingInfo = metadata.timingInfo;
-            const buttonProps = areEqualCursors(focusState.focused, key)
+            const isFocused = areEqualCursors(focusedItem, key);
+            const buttonProps = isFocused
               ? { variant: "warning", disabled: true }
               : { variant: "outline-warning" };
-            const isFocused = areEqualCursors(focusedItem, key);
 
             return (
               <Toast
@@ -570,9 +570,11 @@ export function Timeline({ plan }: { plan: QueryPlan }) {
                     </Button>
                     <Button
                       {...buttonProps}
-                      onClick={() =>
-                        setFocused((state) => focusOnItem(state, key))
-                      }
+                      onClick={() => {
+                        setFocused((state) => focusOnItem(state, key));
+                        setShowChildren(false);
+                        setShowParents(false);
+                      }}
                     >
                       Focus
                     </Button>

--- a/atoti-query-analyser/src/components/Timeline/Timeline.tsx
+++ b/atoti-query-analyser/src/components/Timeline/Timeline.tsx
@@ -138,10 +138,6 @@ const relativeStates: readonly RelativeStateConfig[] = [
     match: (_, focus) => (focus.focused ? [focus.focused] : []),
   },
   {
-    classes: ["selected"],
-    match: (selection) => selection,
-  },
-  {
     classes: ["sibling"],
     match: (_, focus) => focus.siblings,
   },
@@ -152,6 +148,11 @@ const relativeStates: readonly RelativeStateConfig[] = [
   {
     classes: ["child"],
     match: (_, focus) => focus.children,
+  },
+  // Place selected at the end, to focus on the timeline first
+  {
+    classes: ["selected"],
+    match: (selection) => selection,
   },
 ];
 

--- a/atoti-query-analyser/src/components/Timeline/Timeline.tsx
+++ b/atoti-query-analyser/src/components/Timeline/Timeline.tsx
@@ -429,7 +429,6 @@ const computeFocusState = (
       parents,
       children,
     };
-    console.log(result);
     return result;
   }
 };

--- a/atoti-query-analyser/src/components/Timeline/Timeline.tsx
+++ b/atoti-query-analyser/src/components/Timeline/Timeline.tsx
@@ -411,8 +411,9 @@ export function Timeline({ plan }: { plan: QueryPlan }) {
               >
                 <Toast.Header>
                   {kind}&nbsp;
-                  <strong className="mr-auto">#{retrievalId}</strong>
-                  <small>{labels.type(type)}</small>
+                  <span className="retrieval-id mr-auto">#{retrievalId}</span>
+                  &nbsp;
+                  <span className="retrieval-type">{labels.type(type)}</span>
                 </Toast.Header>
                 <Toast.Body className="body">
                   {Details({

--- a/atoti-query-analyser/src/components/Timeline/Timeline.tsx
+++ b/atoti-query-analyser/src/components/Timeline/Timeline.tsx
@@ -325,25 +325,29 @@ export function Timeline({ plan }: { plan: QueryPlan }) {
     return result ?? scales[0];
   }, [plan]);
   const [selection, setSelection] = useState<RetrievalCursor[]>([]);
+  const [focused, setFocused] = useState<RetrievalCursor | null>(null);
   const [scale, setScale] = useState(defaultScale);
 
   useEffect(() => {
     setSelection([]);
+    setFocused(null);
   }, [plan]);
 
   const selectBox = (entry: TimeRange) => {
-    const changed = [...selection];
-    const idx = selection.findIndex(
-      (cursor) =>
-        cursor.id === entry.retrieval.id &&
-        cursor.partition === entry.retrieval.partition
-    );
-    if (idx >= 0) {
-      changed.splice(idx, 1);
-    } else {
-      changed.push(entry.retrieval);
-    }
-    setSelection(changed);
+    setSelection((entries) => {
+      const changed = [...entries];
+      const idx = selection.findIndex(
+        (cursor) =>
+          cursor.id === entry.retrieval.id &&
+          cursor.partition === entry.retrieval.partition
+      );
+      if (idx >= 0) {
+        changed.splice(idx, 1);
+      } else {
+        changed.push(entry.retrieval);
+      }
+      return changed;
+    });
   };
 
   const closeBox = (retrieval: RetrievalCursor) => {

--- a/atoti-query-analyser/src/library/dataStructures/d3/d3Graph.ts
+++ b/atoti-query-analyser/src/library/dataStructures/d3/d3Graph.ts
@@ -17,7 +17,6 @@ function splitIntoLayers(graph: D3Graph): D3Node[][] {
   }
 
   const sortedKeys = Array.from(layersMap.keys()).sort((l, r) => r - l); // Roots has highest Y coordinates
-  console.log(sortedKeys);
 
   const layers = sortedKeys.map((key) => layersMap.get(key) as D3Node[]);
   layers.forEach((layer) =>

--- a/atoti-query-analyser/src/library/devTools/stackTraceParser.ts
+++ b/atoti-query-analyser/src/library/devTools/stackTraceParser.ts
@@ -62,7 +62,7 @@ export class StackTraceParser {
         entry.name ? ", function " + entry.name : ""
       }`;
     } catch (e) {
-      console.log(e);
+      console.error(e);
       return location;
     }
   }

--- a/atoti-query-analyser/src/library/graphProcessors/condenseFastRetrievals.ts
+++ b/atoti-query-analyser/src/library/graphProcessors/condenseFastRetrievals.ts
@@ -219,8 +219,6 @@ class FastRetrievalCondenser {
       retrievalGroups[groupId].push(retrieval);
     });
 
-    console.log(rootSetIndex);
-
     return { groupIdByRetrieval, retrievalGroups };
   }
 


### PR DESCRIPTION
This PR adds new buttons to better highlight information in the timeline.
A first button is "Focus", which moves the focus on a given retrieval for a partition.
The focused item is dark-yellow, while the other selected are blue pale.

On focus, other partitions of the same operation are displaying in pale-yellow.

Button "<" shows the parent retrievals, displayed in red.
![image](https://github.com/activeviam/activeviam.github.io/assets/1181415/616174a2-3d6c-4b14-bd7a-17f3f05b7620)

Button ">" shows the child retrievals, displayed in orange.
![image](https://github.com/activeviam/activeviam.github.io/assets/1181415/ee00cc3a-4b71-43c7-8f7e-c2d4cd7f76bc)

Only the relatives of the focused operation are displayed.

_One caveat here is that parents and children are based on the retrieval id. There is unfortunately no way of finding which partition contribute to which partition._