### PR TITLE
Correct import from a remote server

### DIFF
--- a/atoti-query-analyser/src/components/Summary/Summary.tsx
+++ b/atoti-query-analyser/src/components/Summary/Summary.tsx
@@ -345,7 +345,7 @@ function QuerySummaryView({
       <Button onClick={exportAsJson}>Export graph as JSON</Button>
       <p>Total number of retrievals: {summary.totalRetrievals}</p>
       <p>
-        Total size of external retrieval results:{" "}
+        Total size of database retrieval results:{" "}
         {summary.totalExternalResultSize}
       </p>
       {graph.getVertexCount() > 0 ? (

--- a/atoti-query-analyser/src/components/Timeline/Timeline.css
+++ b/atoti-query-analyser/src/components/Timeline/Timeline.css
@@ -27,11 +27,11 @@
 }
 
 .timeline-box.selected {
-  fill: #64CCC5;
+  fill: #64ccc5;
 }
 
 .timeline-box.focused {
-  fill: #E9B824;
+  fill: #e9b824;
 }
 
 .timeline-box.sibling {
@@ -39,11 +39,11 @@
 }
 
 .timeline-box.parent {
-  fill: #D83F31;
+  fill: #d83f31;
 }
 
 .timeline-box.child {
-  fill: #EE9322;
+  fill: #ee9322;
 }
 
 .timeline-details {

--- a/atoti-query-analyser/src/library/dataStructures/json/jsonQueryPlan.ts
+++ b/atoti-query-analyser/src/library/dataStructures/json/jsonQueryPlan.ts
@@ -75,8 +75,9 @@ function validateJsonQueryPlanModernFormat(
   );
   const dependencies = validateDependencyMap(rawQueryPlan.dependencies);
   const externalRetrievals =
-    optional(rawQueryPlan.externalRetrievals, (retrievals) =>
-      validateList(retrievals, validateExternalRetrieval)
+    optional(
+      rawQueryPlan.externalRetrievals || rawQueryPlan.databaseRetrievals,
+      (retrievals) => validateList(retrievals, validateExternalRetrieval)
     ) ?? [];
   const externalDependencies =
     optional(rawQueryPlan.externalDependencies, validateDependencyMap) ??

--- a/atoti-query-analyser/src/library/inputProcessors/server.ts
+++ b/atoti-query-analyser/src/library/inputProcessors/server.ts
@@ -98,7 +98,7 @@ export async function queryServer({
     credentials: "include",
     headers: {
       "Content-Type": "application/json",
-      Authorization: credentials,
+      Authorization: `Basic ${credentials}`,
     },
     body: JSON.stringify(body),
   });

--- a/atoti-query-analyser/src/library/inputProcessors/server.ts
+++ b/atoti-query-analyser/src/library/inputProcessors/server.ts
@@ -18,7 +18,7 @@ function cleanseUrl(url: string) {
   return match[1];
 }
 
-const supportedApis = ["5", "6", "8"];
+const supportedApis = ["5", "6", "8", "9"];
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const findServiceUrl = (apis: any) => {


### PR DESCRIPTION
Tested against the server 6.1 from the Ranch.

This required to also add support for this new version of Atoti Server.
The only required step was to add the new REST version and rename the key `externalRetrievals` to `databaseRetrievals`.