### PR TITLE
Correctly format double / in the URL, not to remove the ones from the protocol

### DIFF
--- a/atoti-query-analyser/src/library/inputProcessors/server.ts
+++ b/atoti-query-analyser/src/library/inputProcessors/server.ts
@@ -52,7 +52,7 @@ function resolveQueryEndpoint(userUrl: string) {
         const serviceUrl = findServiceUrl(versions.apis);
         const fullUrl =
           `${url}/${serviceUrl}/cube/query/mdx/queryplan`.replaceAll(
-            /\/{2,}/g,
+            /(?<!https?:)\/{2,}/g,
             "/"
           );
         resolve(fullUrl);


### PR DESCRIPTION
This was a bug, creating URL like `https:/url/target` - notice the single `/` after the protocol, resulting in the browser prefixing the URL assumed as local.
