### PR TITLE
add link to the CS student's query plan vis project

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,25 +1,39 @@
 <!DOCTYPE html>
 <html>
-<head>
-  <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width">
-  <title>ActiveViam tools</title>
-</head>
-<body>
-  <h1>ActiveViam tools</h1>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width" />
+    <title>ActiveViam tools</title>
+  </head>
+  <body>
+    <h1>ActiveViam tools</h1>
 
-  <p>This repository regroups a series of tools developed by ActiveViam.</p>
+    <p>This repository regroups a series of tools developed by ActiveViam.</p>
 
-  <h2>List of tools</h2>
-  <ul>
-    <li>
-      <a href="https://activeviam.github.io/flightrecording-analyzer/">Flight Recording Analyzer</a>: Tool analyzing the CSV export of a Java Mission Control flight recording. This regroups the same method together, instead of splitting them by stack trace.
-    </li>
-    <li>
-      <a href="https://activeviam.github.io/atoti-query-analyser/">ActiveViam QueryViz</a>: Query plan analysis tool.
-    </li>
-    <li>
-      <a href="https://activeviam.github.io/queryplan-analyzer/">ActiveViam Query Plan Analyzer</a>: Inspect query plans printed by ActivePivot (no longer maintained).
-    </li>
-  </ul>
-</body>
+    <h2>List of tools</h2>
+    <ul>
+      <li>
+        <a href="https://activeviam.github.io/flightrecording-analyzer/"
+          >Flight Recording Analyzer</a
+        >: Tool analyzing the CSV export of a Java Mission Control flight
+        recording. This regroups the same method together, instead of splitting
+        them by stack trace.
+      </li>
+      <li>
+        <a href="https://queryplan-prototype.activeviam.com/"
+          >ActiveViam Query Plan Visualization (Student project)</a
+        >: Query plan analysis tool.
+      </li>
+      <li>
+        <a href="https://activeviam.github.io/atoti-query-analyser/"
+          >ActiveViam QueryViz</a
+        >: Query plan analysis tool.
+      </li>
+      <li>
+        <a href="https://activeviam.github.io/queryplan-analyzer/"
+          >ActiveViam Query Plan Analyzer</a
+        >: Inspect query plans printed by ActivePivot (no longer maintained).
+      </li>
+    </ul>
+  </body>
+</html>


### PR DESCRIPTION
This PR adds a link to the query plan vis project created by the CS students. The URL is https://queryplan-prototype.activeviam.com/

### How to test
- Go to the homepage
- Click on the `ActiveViam Query Plan Visualization (Student project)` link, it should take you to the URL mentioned above.